### PR TITLE
YCDOCIO-1501: add terraform example from RabbitMQ in clickhouse

### DIFF
--- a/tutorials/terraform/README.md
+++ b/tutorials/terraform/README.md
@@ -7,6 +7,14 @@ All files contains the following resources:
 * Security groups
 * Rules for security groups
 
+## Getting data from RabbitMQ
+
+[Getting data from RabbitMQ](https://cloud.yandex.com/en/docs/managed-clickhouse/tutorials/fetch-data-from-rabbitmq) / [Получение данных из RabbitMQ](https://cloud.yandex.ru/docs/managed-clickhouse/tutorials/fetch-data-from-rabbitmq)
+
+**Files**:
+
+* [clickhouse-cluster-and-vm-for-rabbitmq.md](./clickhouse-cluster-and-vm-for-rabbitmq.md) — Yandex Managed Service for ClickHouse cluster and VM for RabbitMQ
+
 ## Using hybrid storage for Yandex Managed Service for ClickHouse cluster
 
 [Using hybrid storage](https://cloud.yandex.com/en/docs/managed-clickhouse/tutorials/hybrid-storage) / [Использование гибридного хранилища](https://cloud.yandex.ru/docs/managed-clickhouse/tutorials/hybrid-storage).
@@ -15,16 +23,7 @@ All files contains the following resources:
 
 * [clickhouse-hybrid-storage.tf](./clickhouse-hybrid-storage.tf) — Yandex Managed Service for ClickHouse cluster with a hybrid storage.
 
-## Using Managed Service for Redis clusters as PHP session storage
-
-[Using Managed Service for Redis clusters as PHP session storage](https://cloud.yandex.com/en/docs/managed-redis/tutorials/redis-as-php-sessions-storage) / [Использование кластера Managed Service for Redis в качестве хранилища сессий PHP](https://cloud.yandex.ru/docs/managed-redis/tutorials/redis-as-php-sessions-storage)
-
-**Files**:
-
-* [redis-cluster-non-sharded-and-vm.tf](./redis-cluster-non-sharded-and-vm.tf) — non-sharded Yandex Managed Service for Redis cluster and VM.
-* [redis-cluster-sharded-and-vm.tf](./redis-cluster-non-sharded-and-vm.tf) — sharded Yandex Managed Service for Redis cluster and VM.
-
-## Getting data from Managed Service for Apache Kafka
+## Getting data from Yandex Managed Service for Apache Kafka
 
 [Getting data from Managed Service for Apache Kafka](https://cloud.yandex.com/en/docs/managed-clickhouse/tutorials/fetch-data-from-mkf) / [Получение данных из Managed Service for Apache Kafka](https://cloud.yandex.ru/docs/managed-clickhouse/tutorials/fetch-data-from-mkf)
 
@@ -32,10 +31,19 @@ All files contains the following resources:
 
 * [data-from-kafka-to-clickhouse.tf](./data-from-kafka-to-clickhouse/data-from-kafka-to-clickhouse.tf) — Yandex Managed Service for Apache Kafka® cluster and Yandex Managed Service for ClickHouse cluster.
 
+## Using Yandex Managed Service for Redis clusters as PHP session storage
+
+[Using Managed Service for Redis clusters as PHP session storage](https://cloud.yandex.com/en/docs/managed-redis/tutorials/redis-as-php-sessions-storage) / [Использование кластера Managed Service for Redis в качестве хранилища сессий PHP](https://cloud.yandex.ru/docs/managed-redis/tutorials/redis-as-php-sessions-storage)
+
+**Files**:
+
+* [redis-as-php-session-storage/redis-cluster-non-sharded-and-vm.tf](./redis-cluster-non-sharded-and-vm.tf) — non-sharded Yandex Managed Service for Redis cluster and VM.
+* [redis-as-php-session-storage/redis-cluster-sharded-and-vm.tf](./redis-cluster-non-sharded-and-vm.tf) — sharded Yandex Managed Service for Redis cluster and VM.
+
 ## Creating a PostgreSQL cluster for 1C:Enterprise
 
 [Creating a PostgreSQL cluster for 1C:Enterprise](https://cloud.yandex.com/en-ru/docs/managed-postgresql/tutorials/1c-postgresql) / [Создание кластера PostgreSQL для «1С:Предприятия»](https://cloud.yandex.ru/docs/managed-postgresql/tutorials/1c-postgresql)
 
 **Files**:
 
-* [postgresql-1c.tf](./postgresql-1c.tf) — Yandex Managed Service for PostgreSQL cluster for 1С
+* [postgresql-1c.tf](./postgresql-1c.tf) — Yandex Managed Service for PostgreSQL cluster for 1С:Enterprise

--- a/tutorials/terraform/clickhouse-cluster-and-vm-for-rabbitmq.tf
+++ b/tutorials/terraform/clickhouse-cluster-and-vm-for-rabbitmq.tf
@@ -1,0 +1,120 @@
+# Infrastructure for Yandex Cloud Managed Service for ClickHouse cluster and virtual machine
+#
+# RU: https://cloud.yandex.ru/docs/managed-clickhouse/tutorials/fetch-data-from-rabbitmq
+# EN: https://cloud.yandex.com/en/docs/managed-clickhouse/tutorials/fetch-data-from-rabbitmq
+#
+# Set the configuration of Managed Service for ClickHouse cluster and Virtual Machine
+
+
+# Network
+resource "yandex_vpc_network" "clickhouse-and-vm-network" {
+  name        = "clickhouse-and-vm-network"
+  description = "Network for Managed Service for ClickHouse cluster and VM."
+}
+
+# Subnet in ru-central1-a availability zone
+resource "yandex_vpc_subnet" "subnet-a" {
+  name           = "subnet-a"
+  zone           = "ru-central1-a"
+  network_id     = yandex_vpc_network.clickhouse-and-vm-network.id
+  v4_cidr_blocks = ["10.1.0.0/16"]
+}
+
+# Security group for Managed Service for ClickHouse cluster and VM
+resource "yandex_vpc_default_security_group" "clickhouse-and-vm-security-group" {
+  network_id = yandex_vpc_network.clickhouse-and-vm-network.id
+
+  # Allow connections to cluster from the Internet
+  ingress {
+    protocol       = "TCP"
+    description    = "Allow connections from the Internet"
+    port           = 9440
+    v4_cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow connections to RabbitMQ
+  ingress {
+    protocol       = "TCP"
+    description    = "Allow connections to RabbitMQ"
+    port           = 5672
+    v4_cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Allow SSH connections to VM
+  ingress {
+    protocol       = "TCP"
+    description    = "Allow SSH connections to VM from the Internet"
+    port           = 22
+    v4_cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol       = "ANY"
+    description    = "Allow outgoing connections to any required resource"
+    from_port      = 0
+    to_port        = 65535
+    v4_cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Managed Service for ClickHouse cluster
+resource "yandex_mdb_clickhouse_cluster" "clickhouse-cluster" {
+  name               = "clickhouse-cluster"
+  environment        = "PRODUCTION"
+  network_id         = yandex_vpc_network.clickhouse-and-vm-network.id
+  security_group_ids = [yandex_vpc_default_security_group.clickhouse-and-vm-security-group.id]
+
+  clickhouse {
+    resources {
+      resource_preset_id = "s2.micro"
+      disk_type_id       = "network-ssd"
+      disk_size          = 10 # GB
+    }
+  }
+
+  host {
+    type             = "CLICKHOUSE"
+    zone             = "ru-central1-a"
+    subnet_id        = yandex_vpc_subnet.subnet-a.id
+    assign_public_ip = true # Required for connection from the Internet
+  }
+
+  database {
+    name = "db1"
+  }
+
+  user {
+    name     = "" # Set username for ClickHouse cluster
+    password = "" # Set user password for ClickHouse cluster
+    permission {
+      database_name = "db1"
+    }
+  }
+}
+
+# VM in Yandex Compute Cloud
+resource "yandex_compute_instance" "vm-1" {
+
+  name        = "linux-vm"
+  platform_id = "standard-v3" # Intel Ice Lake
+
+  resources {
+    cores  = 2
+    memory = 2 # GB
+  }
+
+  boot_disk {
+    initialize_params {
+      image_id = "" # Set image ID
+    }
+  }
+
+  network_interface {
+    subnet_id = yandex_vpc_subnet.subnet-a.id
+    nat       = true # Required for connection from the Internet
+  }
+
+  metadata = {
+    ssh-keys = "<username>:${file("path for SSH public key")}" # Set username and path for SSH public key
+  }
+}


### PR DESCRIPTION
add terraform example for [Getting data from RabbitMQ](https://cloud.yandex.com/en-ru/docs/managed-clickhouse/tutorials/fetch-data-from-rabbitmq)